### PR TITLE
Focus first item menu open

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,15 +328,11 @@ All props are optional.
 
 *Any additional props (e.g. `id`, `className`, `data-whatever`) are passed directly to the DOM element.*
 
-### openMenu(wrapperId[, openOptions])
+### openMenu(wrapperId)
 
 Open a modal programmatically.
 
 *For this to work, you must provide an `id` prop to the `Wrapper` of the menu.* That `id` should be your first argument to `openMenu()`.
-
-These are the `openOptions`:
-
-- **focusMenu** { Boolean }: If `true`, the menu's first item will receive focus when the menu opens. Default: `false`.
 
 ### closeMenu(wrapperId[, closeOptions])
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,10 +17,10 @@
     <h2 tabindex="0">Some interactions you should try</h2>
     <ul>
       <li>
-        Click the trigger to toggle the menu.
+        Click the trigger to toggle the menu. The first menu item should be automatically focused when opened.
       </li>
       <li>
-        With focus on the trigger, press Enter or Space to toggle the menu.
+        With focus on the trigger, press Enter or Space to toggle the menu. The first menu item should be automatically focused when opened.
       </li>
       <li>
         With the menu opened and focus on the trigger, press ArrowDown to move focus to the first menu item.

--- a/lib/Button.js
+++ b/lib/Button.js
@@ -36,16 +36,12 @@ module.exports = React.createClass({
     switch (event.key) {
       case 'ArrowDown':
         event.preventDefault();
-        if (!ambManager.isOpen) {
-          ambManager.openMenu({ focusMenu: true });
-        } else {
-          ambManager.focusItem(0);
-        }
+        ambManager.openMenu();
         break;
       case 'Enter':
       case ' ':
         event.preventDefault();
-        ambManager.toggleMenu();
+        ambManager.openMenu();
         break;
       case 'Escape':
         ambManager.handleMenuKey(event);
@@ -58,7 +54,7 @@ module.exports = React.createClass({
 
   handleClick: function() {
     if (this.props.disabled) return;
-    this.context.ambManager.toggleMenu();
+    this.context.ambManager.openMenu();
   },
 
   render: function() {

--- a/lib/createManager.js
+++ b/lib/createManager.js
@@ -69,18 +69,17 @@ var protoManager = {
     this.button.setState({ menuOpen: this.isOpen });
   },
 
-  openMenu: function(openOptions) {
-    if (this.isOpen) return;
-    openOptions = openOptions || {};
-    this.isOpen = true;
-    this.update();
-    this.focusGroup.activate();
-    if (openOptions.focusMenu) {
-      var self = this;
-      this.moveFocusTimer = setTimeout(function() {
-        self.focusItem(0)
-      }, 0);
+  openMenu: function() {
+    if (!this.isOpen) {
+      this.isOpen = true;
+      this.update();
     }
+
+    this.focusGroup.activate();
+    var self = this;
+    this.moveFocusTimer = setTimeout(function() {
+      self.focusItem(0)
+    }, 0);
   },
 
   closeMenu: function(closeOptions) {

--- a/lib/externalStateControl.js
+++ b/lib/externalStateControl.js
@@ -10,10 +10,10 @@ function unregisterManager(menuId) {
   delete registeredManagers[menuId];
 }
 
-function openMenu(menuId, openOptions) {
+function openMenu(menuId) {
   var manager = registeredManagers[menuId];
   if (!manager) throw new Error('Cannot open ' + errorCommon);
-  manager.openMenu(openOptions);
+  manager.openMenu();
 }
 
 function closeMenu(menuId, closeOptions) {

--- a/test/Button-test.js
+++ b/test/Button-test.js
@@ -140,7 +140,6 @@ test('Button keyDown', function(t) {
     ReactTestUtils.Simulate.keyDown(renderedButtonNode, downEvent);
     st.ok(downEvent.preventDefault.calledOnce, 'calls event.preventDefault');
     st.ok(manager.openMenu.calledOnce, 'calls open menu');
-    st.deepEqual(manager.openMenu.getCall(0).args, [{ focusMenu: true }], 'calls focuses menu when it opens');
     st.end();
   });
 
@@ -157,14 +156,14 @@ test('Button keyDown', function(t) {
   t.test('enter', function(st) {
     ReactTestUtils.Simulate.keyDown(renderedButtonNode, enterEvent);
     st.ok(enterEvent.preventDefault.calledOnce, 'enter calls event.preventDefault');
-    st.ok(manager.toggleMenu.calledOnce, 'enter calls toggleMenu');
+    st.ok(manager.openMenu.calledOnce, 'calls open menu');
     st.end();
   });
 
   t.test('space', function(st) {
     ReactTestUtils.Simulate.keyDown(renderedButtonNode, spaceEvent);
     st.ok(spaceEvent.preventDefault.calledOnce, 'space calls event.preventDefault');
-    st.ok(manager.toggleMenu.calledTwice, 'space calls toggleMenu');
+    st.ok(manager.openMenu.calledOnce, 'calls open menu');
     st.end();
   });
 

--- a/test/Button-test.js
+++ b/test/Button-test.js
@@ -105,7 +105,7 @@ test('Button click', function(t) {
   var renderedButtonNode = ReactDOM.findDOMNode(renderedButton);
 
   ReactTestUtils.Simulate.click(renderedButtonNode);
-  t.ok(renderedWrapper.manager.toggleMenu.calledOnce);
+  t.ok(renderedWrapper.manager.openMenu.calledOnce);
 
   var disabledRenderedWrapper = ReactTestUtils.renderIntoDocument(
     el(MockWrapper, { mockManager: mockManager() },

--- a/test/Manager-test.js
+++ b/test/Manager-test.js
@@ -54,21 +54,10 @@ test('Manager#update', function(t) {
   t.end();
 });
 
-test('Manager#openMenu without focusing in menu', function(t) {
-  var m = mockManager();
-
-  m.openMenu();
-  t.ok(m.isOpen);
-  t.ok(m.menu.setState.calledWith({ isOpen: true }));
-  t.ok(m.button.setState.calledWith({ menuOpen: true }));
-
-  t.end();
-});
-
 test('Manager#openMenu focusing in menu', function(t) {
   var m = mockManager();
   t.plan(4);
-  m.openMenu({ focusMenu: true });
+  m.openMenu();
   t.ok(m.isOpen, 'opens');
   t.ok(m.menu.setState.calledWith({ isOpen: true }), 'sets open state on menu');
   t.ok(m.button.setState.calledWith({ menuOpen: true }), 'sets open state on button');


### PR DESCRIPTION
@ebsco/developers, as [per the original author](https://github.com/davidtheclark/react-aria-menubutton/issues/51#issuecomment-252272283), focusing on first menu item when opening the menu should be part of the core library; the library should match what is specified in [wai-aria practices guide](https://www.w3.org/TR/wai-aria-practices/#menu).
